### PR TITLE
Add getNavList function

### DIFF
--- a/src/components/Header/getHeader.ts
+++ b/src/components/Header/getHeader.ts
@@ -1,4 +1,4 @@
-import setCurrentPageIndicator from "../utils/setCurrentPageIndicator";
+import getNavList from "../../getNavList/getNavList";
 import "./Header.css";
 
 const getHeader = (handleShowSidebar: () => void): HTMLElement => {
@@ -29,11 +29,7 @@ const getHeader = (handleShowSidebar: () => void): HTMLElement => {
   const headerNav = document.createElement("nav");
   headerNav.className = "main-header__nav";
 
-  const navList = document.createElement("ul");
-  navList.className = "nav-list";
-  navList.innerHTML = "<li><a class='nav-list__item' href='/'>Home</a></li>";
-
-  setCurrentPageIndicator(navList);
+  const navList = getNavList();
 
   headerNav.appendChild(navList);
 

--- a/src/components/SidebarMenu/SidebarMenu.css
+++ b/src/components/SidebarMenu/SidebarMenu.css
@@ -39,4 +39,5 @@
 
 .nav-list--vertical {
   flex-direction: column;
+  gap: 35px;
 }

--- a/src/components/SidebarMenu/getSidebarMenu.ts
+++ b/src/components/SidebarMenu/getSidebarMenu.ts
@@ -1,4 +1,4 @@
-import setCurrentPageIndicator from "../utils/setCurrentPageIndicator";
+import getNavList from "../../getNavList/getNavList";
 import "./SidebarMenu.css";
 
 const getSidebarMenu = (): HTMLElement => {
@@ -26,10 +26,8 @@ const getSidebarMenu = (): HTMLElement => {
   const sidebarMenu = document.createElement("nav");
   sidebarMenu.className = "sidebar-menu";
 
-  const navList = document.createElement("ul");
-  navList.classList.add("nav-list", "nav-list--vertical");
-  navList.innerHTML = "<li><a class='nav-list__item' href='/'>Home</a></li>";
-  setCurrentPageIndicator(navList);
+  const navList = getNavList();
+  navList.classList.add("nav-list--vertical");
 
   const sidebarButton = document.createElement("button");
   sidebarButton.className = "close-sidebar-button";

--- a/src/getNavList/getNavList.test.ts
+++ b/src/getNavList/getNavList.test.ts
@@ -1,0 +1,19 @@
+import getNavList from "./getNavList";
+
+describe("Given the getNavList function", () => {
+  describe("When it is called", () => {
+    test("Then it should show a link to home", () => {
+      const screen = document.createElement("div");
+
+      const expectedAnchorText = "Home";
+
+      const navList = getNavList();
+      screen.appendChild(navList);
+
+      const anchorElement = screen.querySelector("a");
+
+      expect(anchorElement).not.toBeNull();
+      expect(anchorElement?.textContent).toBe(expectedAnchorText);
+    });
+  });
+});

--- a/src/getNavList/getNavList.ts
+++ b/src/getNavList/getNavList.ts
@@ -1,4 +1,8 @@
-const setCurrentPageIndicator = (navList: HTMLElement): void => {
+const getNavList = (): HTMLElement => {
+  const navList = document.createElement("ul");
+  navList.className = "nav-list";
+  navList.innerHTML = "<li><a class='nav-list__item' href='/'>Home</a></li>";
+
   const navListItems = navList.querySelectorAll("a");
 
   navListItems.forEach((navListItem) => {
@@ -7,6 +11,8 @@ const setCurrentPageIndicator = (navList: HTMLElement): void => {
 
     navListItem.classList.toggle("nav-list__item--current", isCurrentPage);
   });
+
+  return navList;
 };
 
-export default setCurrentPageIndicator;
+export default getNavList;


### PR DESCRIPTION
Added getNavList function and removed setCurrentPageIndicator function. Now both mobile and desktop applications with always have the same navigation list, and at the same time, making the behavior more testable.